### PR TITLE
Fix decoding of uncompressed payloads

### DIFF
--- a/client_libraries/javascript/sparkplug-client/index.js
+++ b/client_libraries/javascript/sparkplug-client/index.js
@@ -216,7 +216,7 @@ function SparkplugClient(config) {
             return decodePayload(decompressPayload(payload));
         } else {
             // The payload is not compressed
-            return decodePayload(payload);
+            return payload;
         }
     };
 


### PR DESCRIPTION
Hi everyone,

I've been working on integrating SparkPlug into both our devices and cloud app after a great call with Arlen. The work you've done on the client libraries so far is excellent.

As I've made my own changes and improvements to the javascript client, I've worked off your develop branch, to make it as easy as possible to merge back changes and fixes. I noticed here that the app was crashing because the "maybe decompress" logic is wrong. Should be a simple fix to merge!

Thanks!

-Jason