### PR TITLE
Removed redundant class definition for ParameterDataType

### DIFF
--- a/client_libraries/python/sparkplug_b.py
+++ b/client_libraries/python/sparkplug_b.py
@@ -61,23 +61,6 @@ class ParameterDataType:
     DateTime = 13
     Text = 14
 
-class ParameterDataType:
-    Unknown = 0
-    Int8 = 1
-    Int16 = 2
-    Int32 = 3
-    Int64 = 4
-    UInt8 = 5
-    UInt16 = 6
-    UInt32 = 7
-    UInt64 = 8
-    Float = 9
-    Double = 10
-    Boolean = 11
-    String = 12
-    DateTime = 13
-    Text = 14
-
 ######################################################################
 # Always request this before requesting the Node Birth Payload
 ######################################################################


### PR DESCRIPTION
Please let me know if there was a reason for the duplicate definitions.